### PR TITLE
feat: multi-user playback isolation (issue #41)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,6 +180,18 @@
 
 ---
 
+## Phase 7.1 — Isolation multi-utilisateur de la lecture ✅ Terminé (v1.8.1) — issue #41
+
+- [x] **`sessionKey` inclut le `userId` local** : `{connectorId}:{remoteItemId}:{localUserId}` — élimine la race condition quand 2 users regardent le même item simultanément
+- [x] **`LocalUserId` dans `ConnectorConfig`** : champ permettant de lier un connecteur à un user local spécifique ; sélecteur dans l'UI de configuration
+- [x] **Sessions isolées sur le distant** : `playSessionId` utilisé comme `DeviceId` dans `X-Emby-Authorization` → chaque stream apparaît comme une session distincte sur le dashboard du serveur distant
+- [x] **Identité dynamique** : `deviceName` au format `user@client` (ex: `cyril@Emby Web`) propagé dans tous les appels playback (Emby + Plex)
+- [x] **Isolation des Progress** : seul le user lié (A) envoie ses Progress au distant ; les autres users (B) maintiennent leur position localement (évite l'oscillation de `UserData.PlaybackPositionTicks`)
+- [x] **Restauration de position au Stop(B)** (`ResolveLinkedUserPosition`) : au Stop d'un user non-lié, on envoie la position de A (depuis session active ou `IUserDataManager.GetUserData`) au lieu de 0 — préserve le resume point de A sur le serveur distant
+- [x] **`SyncUserFlags` ciblé** : sync des états vu/favori/position uniquement vers le user lié (`LocalUserId`), plus vers tous les users locaux
+
+---
+
 ## Phase 7 — Backpropagation de la lecture ✅ Terminé (v1.7.0) — issue #34
 
 - [x] **`PlaybackEventForwarder`** (`IServerEntryPoint`) : s'abonne aux events `ISessionManager` (Start / Progress / Stop) et propage les notifications vers le serveur distant via le connecteur correspondant

--- a/docs/core/OVERVIEW.md
+++ b/docs/core/OVERVIEW.md
@@ -120,6 +120,10 @@ public class ConnectorConfig
     // SharedByType : médiathèque Emby partagée par type (Movies, TvShows…)
     // Dans les deux cas, fichiers physiques dans virtualLibRoot/ConnectorName/LibraryName/
     public LibraryOrganization LibraryOrganization { get; set; } = LibraryOrganization.Isolated;
+    // User local dont les données personnelles (vu, favori, position) sont synchronisées
+    // avec ce connecteur. Les autres users ont leurs sessions forwardées mais leurs
+    // données personnelles restent locales (issue #41).
+    public string LocalUserId { get; set; } = string.Empty;
 }
 ```
 

--- a/src/VirtualLib/Api/ConfigController.cs
+++ b/src/VirtualLib/Api/ConfigController.cs
@@ -37,6 +37,7 @@ public sealed class CreateConnector : IReturn<ConnectorConfig>
     public bool Enabled { get; set; } = true;
     public int MaxParallelLibraries { get; set; } = 4;
     public LibraryOrganization LibraryOrganization { get; set; } = LibraryOrganization.Isolated;
+    public string LocalUserId { get; set; } = string.Empty;
 }
 
 [Route("/virtuallib/connectors/{Id}", "PUT", Summary = "Update an existing connector")]
@@ -57,6 +58,7 @@ public sealed class UpdateConnector : IReturn<ConnectorConfig>
     public bool Enabled { get; set; } = true;
     public int MaxParallelLibraries { get; set; } = 4;
     public LibraryOrganization LibraryOrganization { get; set; } = LibraryOrganization.Isolated;
+    public string LocalUserId { get; set; } = string.Empty;
 }
 
 [Route("/virtuallib/connectors/{Id}", "DELETE", Summary = "Remove a connector")]
@@ -330,7 +332,8 @@ public sealed class ConfigController : BaseApiService
             LibraryIds = request.LibraryIds,
             Enabled = request.Enabled,
             MaxParallelLibraries = Math.Max(1, request.MaxParallelLibraries),
-            LibraryOrganization = request.LibraryOrganization
+            LibraryOrganization = request.LibraryOrganization,
+            LocalUserId = request.LocalUserId
         };
 
         config.Connectors.Add(connector);
@@ -369,7 +372,8 @@ public sealed class ConfigController : BaseApiService
             Enabled = request.Enabled,
             KnownLibraries = existing.KnownLibraries,
             MaxParallelLibraries = Math.Max(1, request.MaxParallelLibraries),
-            LibraryOrganization = request.LibraryOrganization
+            LibraryOrganization = request.LibraryOrganization,
+            LocalUserId = request.LocalUserId
         };
 
         config.Connectors.Add(updated);
@@ -910,7 +914,7 @@ public sealed class ConfigController : BaseApiService
                 var prog2 = new Progress<SyncProgress>(p =>
                     SyncState.UpdatePhase2(conn.Id, libraryId, p.Current, p.Total));
 
-                await syncSvc.PushMetadataAsync(lp.Items, lp.LibraryName, prog2, ct);
+                await syncSvc.PushMetadataAsync(lp.Items, lp.LibraryName, prog2, ct, conn.LocalUserId);
             }
 
             SyncState.MarkDone(conn.Id, libraryId);

--- a/src/VirtualLib/Connectors/EmbyConnector.cs
+++ b/src/VirtualLib/Connectors/EmbyConnector.cs
@@ -13,9 +13,26 @@ public sealed class EmbyConnector : IMediaServerConnector
     private const int PageSize = 100;
     private const string EmbyTokenHeader = "X-Emby-Token";
 
+    private static readonly string PluginVersion =
+        typeof(EmbyConnector).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
+
     private readonly ConnectorConfig _config;
     private readonly HttpClient _httpClient;
     private readonly ILogger<EmbyConnector> _logger;
+
+    /// <summary>
+    /// Human-readable device name shown on the remote server.
+    /// "VirtualLib for &lt;username&gt;" in UserCredentials mode,
+    /// "VirtualLib for &lt;DisplayName&gt;" in ApiKey mode.
+    /// </summary>
+    private string ClientDeviceName =>
+        "VirtualLib for " + (_config.AuthMode == AuthMode.UserCredentials && !string.IsNullOrEmpty(_config.Username)
+            ? _config.Username
+            : _config.DisplayName);
+
+    /// <summary>Builds the X-Emby-Authorization header value for the given deviceId.</summary>
+    private string EmbyAuthHeader(string deviceId) =>
+        $"MediaBrowser Client=\"VirtualLib\", Device=\"{ClientDeviceName}\", DeviceId=\"{deviceId}\", Version=\"{PluginVersion}\"";
 
     // User-credentials session state
     private string? _sessionToken;
@@ -73,7 +90,7 @@ public sealed class EmbyConnector : IMediaServerConnector
             var authRequest = new HttpRequestMessage(HttpMethod.Post, "Users/AuthenticateByName");
             authRequest.Headers.TryAddWithoutValidation(
                 "X-Emby-Authorization",
-                "MediaBrowser Client=\"VirtualLib\", Device=\"VirtualLib Plugin\", DeviceId=\"VirtualLib\", Version=\"1.0.0\"");
+                EmbyAuthHeader(_config.Id));
             authRequest.Content = new StringContent(bodyJson, System.Text.Encoding.UTF8, "application/json");
 
             using var response = await _httpClient.SendAsync(authRequest, ct);
@@ -515,7 +532,7 @@ public sealed class EmbyConnector : IMediaServerConnector
         // on the remote Emby server, preventing sessions from overwriting each other.
         request.Headers.TryAddWithoutValidation(
             "X-Emby-Authorization",
-            $"MediaBrowser Client=\"VirtualLib\", Device=\"VirtualLib Plugin\", DeviceId=\"{playSessionId}\", Version=\"1.0.0\"");
+            EmbyAuthHeader(playSessionId));
 
         return await _httpClient.SendAsync(request, ct);
     }

--- a/src/VirtualLib/Connectors/EmbyConnector.cs
+++ b/src/VirtualLib/Connectors/EmbyConnector.cs
@@ -439,7 +439,7 @@ public sealed class EmbyConnector : IMediaServerConnector
                 CanSeek = true,
                 QueueableMediaTypes = new[] { "Video" }
             };
-            using var response = await PostWithRetryAsync("Sessions/Playing", body, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing", body, playSessionId, cancellationToken);
             _logger.LogDebug("Reported PlaybackStart for item={ItemId} session={Session}", itemId, playSessionId);
         }
         catch (Exception ex)
@@ -463,7 +463,7 @@ public sealed class EmbyConnector : IMediaServerConnector
                 PositionTicks = positionTicks,
                 IsPaused = isPaused
             };
-            using var response = await PostWithRetryAsync("Sessions/Playing/Progress", body, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing/Progress", body, playSessionId, cancellationToken);
             _logger.LogDebug("Reported PlaybackProgress for item={ItemId} pos={Ticks}", itemId, positionTicks);
         }
         catch (Exception ex)
@@ -486,13 +486,38 @@ public sealed class EmbyConnector : IMediaServerConnector
                 UserId = userId,
                 PositionTicks = positionTicks
             };
-            using var response = await PostWithRetryAsync("Sessions/Playing/Stopped", body, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing/Stopped", body, playSessionId, cancellationToken);
             _logger.LogDebug("Reported PlaybackStopped for item={ItemId} session={Session}", itemId, playSessionId);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to report PlaybackStopped for item {ItemId}", itemId);
         }
+    }
+
+    /// <summary>
+    /// Posts a playback event (Start/Progress/Stopped) with a per-session DeviceId in
+    /// X-Emby-Authorization so that concurrent streams appear as distinct devices on the
+    /// remote server. Without this, all streams from the same connector share a single
+    /// hardcoded DeviceId and the remote server conflates them into one active session.
+    /// </summary>
+    private async Task<HttpResponseMessage> PostPlaybackAsync<T>(
+        string url, T body, string playSessionId, CancellationToken ct)
+    {
+        var bodyJson = System.Text.Json.JsonSerializer.Serialize(body);
+        var content  = new StringContent(bodyJson, System.Text.Encoding.UTF8, "application/json");
+
+        await EnsureAuthenticatedAsync(ct);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = content;
+        // Use playSessionId as DeviceId: each concurrent stream is a distinct "device"
+        // on the remote Emby server, preventing sessions from overwriting each other.
+        request.Headers.TryAddWithoutValidation(
+            "X-Emby-Authorization",
+            $"MediaBrowser Client=\"VirtualLib\", Device=\"VirtualLib Plugin\", DeviceId=\"{playSessionId}\", Version=\"1.0.0\"");
+
+        return await _httpClient.SendAsync(request, ct);
     }
 
     // -------------------------------------------------------------------------

--- a/src/VirtualLib/Connectors/EmbyConnector.cs
+++ b/src/VirtualLib/Connectors/EmbyConnector.cs
@@ -30,9 +30,12 @@ public sealed class EmbyConnector : IMediaServerConnector
             ? _config.Username
             : _config.DisplayName);
 
-    /// <summary>Builds the X-Emby-Authorization header value for the given deviceId.</summary>
-    private string EmbyAuthHeader(string deviceId) =>
-        $"MediaBrowser Client=\"VirtualLib\", Device=\"{ClientDeviceName}\", DeviceId=\"{deviceId}\", Version=\"{PluginVersion}\"";
+    /// <summary>
+    /// Builds the X-Emby-Authorization header value.
+    /// <paramref name="deviceName"/> overrides the connector-level name when provided (e.g. "cyril@Emby Web").
+    /// </summary>
+    private string EmbyAuthHeader(string deviceId, string? deviceName = null) =>
+        $"MediaBrowser Client=\"VirtualLib\", Device=\"{deviceName ?? ClientDeviceName}\", DeviceId=\"{deviceId}\", Version=\"{PluginVersion}\"";
 
     // User-credentials session state
     private string? _sessionToken;
@@ -441,7 +444,7 @@ public sealed class EmbyConnector : IMediaServerConnector
         }
     }
 
-    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, string deviceName, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -456,7 +459,7 @@ public sealed class EmbyConnector : IMediaServerConnector
                 CanSeek = true,
                 QueueableMediaTypes = new[] { "Video" }
             };
-            using var response = await PostPlaybackAsync("Sessions/Playing", body, playSessionId, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing", body, playSessionId, deviceName, cancellationToken);
             _logger.LogDebug("Reported PlaybackStart for item={ItemId} session={Session}", itemId, playSessionId);
         }
         catch (Exception ex)
@@ -465,7 +468,7 @@ public sealed class EmbyConnector : IMediaServerConnector
         }
     }
 
-    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, string deviceName, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -480,7 +483,7 @@ public sealed class EmbyConnector : IMediaServerConnector
                 PositionTicks = positionTicks,
                 IsPaused = isPaused
             };
-            using var response = await PostPlaybackAsync("Sessions/Playing/Progress", body, playSessionId, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing/Progress", body, playSessionId, deviceName, cancellationToken);
             _logger.LogDebug("Reported PlaybackProgress for item={ItemId} pos={Ticks}", itemId, positionTicks);
         }
         catch (Exception ex)
@@ -489,7 +492,7 @@ public sealed class EmbyConnector : IMediaServerConnector
         }
     }
 
-    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, long positionTicks, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, string deviceName, long positionTicks, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -503,7 +506,7 @@ public sealed class EmbyConnector : IMediaServerConnector
                 UserId = userId,
                 PositionTicks = positionTicks
             };
-            using var response = await PostPlaybackAsync("Sessions/Playing/Stopped", body, playSessionId, cancellationToken);
+            using var response = await PostPlaybackAsync("Sessions/Playing/Stopped", body, playSessionId, deviceName, cancellationToken);
             _logger.LogDebug("Reported PlaybackStopped for item={ItemId} session={Session}", itemId, playSessionId);
         }
         catch (Exception ex)
@@ -513,13 +516,12 @@ public sealed class EmbyConnector : IMediaServerConnector
     }
 
     /// <summary>
-    /// Posts a playback event (Start/Progress/Stopped) with a per-session DeviceId in
-    /// X-Emby-Authorization so that concurrent streams appear as distinct devices on the
-    /// remote server. Without this, all streams from the same connector share a single
-    /// hardcoded DeviceId and the remote server conflates them into one active session.
+    /// Posts a playback event with a per-session DeviceId and per-session Device name in
+    /// X-Emby-Authorization. Each concurrent stream appears as a distinct device on the
+    /// remote server (DeviceId = playSessionId) with a human-readable name (deviceName).
     /// </summary>
     private async Task<HttpResponseMessage> PostPlaybackAsync<T>(
-        string url, T body, string playSessionId, CancellationToken ct)
+        string url, T body, string playSessionId, string deviceName, CancellationToken ct)
     {
         var bodyJson = System.Text.Json.JsonSerializer.Serialize(body);
         var content  = new StringContent(bodyJson, System.Text.Encoding.UTF8, "application/json");
@@ -528,11 +530,9 @@ public sealed class EmbyConnector : IMediaServerConnector
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Content = content;
-        // Use playSessionId as DeviceId: each concurrent stream is a distinct "device"
-        // on the remote Emby server, preventing sessions from overwriting each other.
         request.Headers.TryAddWithoutValidation(
             "X-Emby-Authorization",
-            EmbyAuthHeader(playSessionId));
+            EmbyAuthHeader(playSessionId, deviceName));
 
         return await _httpClient.SendAsync(request, ct);
     }

--- a/src/VirtualLib/Connectors/PlexConnector.cs
+++ b/src/VirtualLib/Connectors/PlexConnector.cs
@@ -11,6 +11,9 @@ public sealed class PlexConnector : IMediaServerConnector
     private const int PageSize = 100;
     private const string PlexTokenHeader = "X-Plex-Token";
 
+    private static readonly string PluginVersion =
+        typeof(PlexConnector).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
+
     private readonly ConnectorConfig _config;
     private readonly HttpClient _httpClient;
     private readonly ILogger<PlexConnector> _logger;
@@ -36,8 +39,8 @@ public sealed class PlexConnector : IMediaServerConnector
         _httpClient.Timeout = TimeSpan.FromSeconds(120);
 
         _httpClient.DefaultRequestHeaders.Add("X-Plex-Product", "VirtualLib");
-        _httpClient.DefaultRequestHeaders.Add("X-Plex-Client-Identifier", "virtuallib-plugin");
-        _httpClient.DefaultRequestHeaders.Add("X-Plex-Version", "1.0.0");
+        _httpClient.DefaultRequestHeaders.Add("X-Plex-Client-Identifier", config.Id);
+        _httpClient.DefaultRequestHeaders.Add("X-Plex-Version", PluginVersion);
 
         _plexToken = config.AuthMode == AuthMode.ApiKey ? config.ApiKey : string.Empty;
         if (!string.IsNullOrEmpty(_plexToken))
@@ -62,8 +65,8 @@ public sealed class PlexConnector : IMediaServerConnector
 
             using var plexTvClient = new HttpClient();
             plexTvClient.DefaultRequestHeaders.Add("X-Plex-Product", "VirtualLib");
-            plexTvClient.DefaultRequestHeaders.Add("X-Plex-Client-Identifier", "virtuallib-plugin");
-            plexTvClient.DefaultRequestHeaders.Add("X-Plex-Version", "1.0.0");
+            plexTvClient.DefaultRequestHeaders.Add("X-Plex-Client-Identifier", _config.Id);
+            plexTvClient.DefaultRequestHeaders.Add("X-Plex-Version", PluginVersion);
             plexTvClient.DefaultRequestHeaders.Add("Accept", "application/xml");
 
             var form = new FormUrlEncodedContent(new[]

--- a/src/VirtualLib/Connectors/PlexConnector.cs
+++ b/src/VirtualLib/Connectors/PlexConnector.cs
@@ -377,25 +377,25 @@ public sealed class PlexConnector : IMediaServerConnector
     // Playback reporting — Plex /:/timeline endpoint
     // -------------------------------------------------------------------------
 
-    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, string deviceName, CancellationToken cancellationToken = default)
     {
-        try { await ReportTimelineAsync(itemId, "playing", 0L, playSessionId, cancellationToken); }
+        try { await ReportTimelineAsync(itemId, "playing", 0L, playSessionId, deviceName, cancellationToken); }
         catch (Exception ex) { _logger.LogDebug(ex, "Failed to report PlaybackStart for item {ItemId}", itemId); }
     }
 
-    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, string deviceName, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
     {
         try
         {
             var state = isPaused ? "paused" : "playing";
-            await ReportTimelineAsync(itemId, state, positionTicks / 10_000L, playSessionId, cancellationToken);
+            await ReportTimelineAsync(itemId, state, positionTicks / 10_000L, playSessionId, deviceName, cancellationToken);
         }
         catch (Exception ex) { _logger.LogDebug(ex, "Failed to report PlaybackProgress for item {ItemId}", itemId); }
     }
 
-    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, long positionTicks, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, string deviceName, long positionTicks, CancellationToken cancellationToken = default)
     {
-        try { await ReportTimelineAsync(itemId, "stopped", positionTicks / 10_000L, playSessionId, cancellationToken); }
+        try { await ReportTimelineAsync(itemId, "stopped", positionTicks / 10_000L, playSessionId, deviceName, cancellationToken); }
         catch (Exception ex) { _logger.LogDebug(ex, "Failed to report PlaybackStopped for item {ItemId}", itemId); }
     }
 
@@ -405,7 +405,7 @@ public sealed class PlexConnector : IMediaServerConnector
     /// la position (time en ms) et la progression (viewOffset).
     /// X-Plex-Session-Identifier est envoyé par requête car chaque session a son propre ID.
     /// </summary>
-    private async Task ReportTimelineAsync(string itemId, string state, long positionMs, string playSessionId, CancellationToken ct)
+    private async Task ReportTimelineAsync(string itemId, string state, long positionMs, string playSessionId, string deviceName, CancellationToken ct)
     {
         await EnsureAuthenticatedAsync(ct);
 
@@ -422,6 +422,8 @@ public sealed class PlexConnector : IMediaServerConnector
 
         using var timelineRequest = new HttpRequestMessage(HttpMethod.Get, timelineUrl);
         timelineRequest.Headers.TryAddWithoutValidation("X-Plex-Session-Identifier", playSessionId);
+        if (!string.IsNullOrEmpty(deviceName))
+            timelineRequest.Headers.TryAddWithoutValidation("X-Plex-Device-Name", deviceName);
         using var timelineResponse = await _httpClient.SendAsync(timelineRequest, ct);
 
         var timelineBody = timelineResponse.IsSuccessStatusCode ? string.Empty

--- a/src/VirtualLib/Connectors/PlexTvConnector.cs
+++ b/src/VirtualLib/Connectors/PlexTvConnector.cs
@@ -315,22 +315,22 @@ public sealed class PlexTvConnector : IMediaServerConnector
         return await inner.GetArtworkStreamAsync(itemId, artworkType, cancellationToken);
     }
 
-    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStartAsync(string itemId, string playSessionId, string deviceName, CancellationToken cancellationToken = default)
     {
         var inner = await GetInnerAsync(cancellationToken);
-        await inner.ReportPlaybackStartAsync(itemId, playSessionId, cancellationToken);
+        await inner.ReportPlaybackStartAsync(itemId, playSessionId, deviceName, cancellationToken);
     }
 
-    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackProgressAsync(string itemId, string playSessionId, string deviceName, long positionTicks, bool isPaused, CancellationToken cancellationToken = default)
     {
         var inner = await GetInnerAsync(cancellationToken);
-        await inner.ReportPlaybackProgressAsync(itemId, playSessionId, positionTicks, isPaused, cancellationToken);
+        await inner.ReportPlaybackProgressAsync(itemId, playSessionId, deviceName, positionTicks, isPaused, cancellationToken);
     }
 
-    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, long positionTicks, CancellationToken cancellationToken = default)
+    public async Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, string deviceName, long positionTicks, CancellationToken cancellationToken = default)
     {
         var inner = await GetInnerAsync(cancellationToken);
-        await inner.ReportPlaybackStoppedAsync(itemId, playSessionId, positionTicks, cancellationToken);
+        await inner.ReportPlaybackStoppedAsync(itemId, playSessionId, deviceName, positionTicks, cancellationToken);
     }
 
     public void Dispose()

--- a/src/VirtualLib/Connectors/PlexTvConnector.cs
+++ b/src/VirtualLib/Connectors/PlexTvConnector.cs
@@ -16,6 +16,9 @@ public sealed class PlexTvConnector : IMediaServerConnector
 {
     private const string PlexTvBase = "https://plex.tv";
 
+    private static readonly string PluginVersion =
+        typeof(PlexTvConnector).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
+
     private readonly ConnectorConfig _config;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILoggerFactory _loggerFactory;
@@ -247,7 +250,7 @@ public sealed class PlexTvConnector : IMediaServerConnector
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add("X-Plex-Product",          "VirtualLib");
         client.DefaultRequestHeaders.Add("X-Plex-Client-Identifier", "virtuallib-plugin");
-        client.DefaultRequestHeaders.Add("X-Plex-Version",           "1.0.0");
+        client.DefaultRequestHeaders.Add("X-Plex-Version",           PluginVersion);
         client.DefaultRequestHeaders.Add("Accept",                   "application/json");
         return client;
     }

--- a/src/VirtualLib/Core/IMediaServerConnector.cs
+++ b/src/VirtualLib/Core/IMediaServerConnector.cs
@@ -71,17 +71,19 @@ public interface IMediaServerConnector : IDisposable
     /// Notifie le serveur distant qu'une lecture vient de démarrer.
     /// <paramref name="playSessionId"/> est un GUID unique par session de lecture,
     /// à réutiliser dans les appels Progress et Stopped correspondants.
+    /// <paramref name="deviceName"/> identifie le client local sous la forme "user@app"
+    /// (ex: "cyril@Emby Web") tel qu'il apparaîtra dans le tableau de bord du serveur distant.
     /// </summary>
-    Task ReportPlaybackStartAsync(string itemId, string playSessionId, CancellationToken cancellationToken = default);
+    Task ReportPlaybackStartAsync(string itemId, string playSessionId, string deviceName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Envoie la position de lecture courante au serveur distant (~toutes les 10s).
     /// </summary>
-    Task ReportPlaybackProgressAsync(string itemId, string playSessionId, long positionTicks, bool isPaused, CancellationToken cancellationToken = default);
+    Task ReportPlaybackProgressAsync(string itemId, string playSessionId, string deviceName, long positionTicks, bool isPaused, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Notifie le serveur distant que la lecture s'est arrêtée.
     /// <paramref name="positionTicks"/> est la position finale (en ticks) pour sauvegarder l'avancement.
     /// </summary>
-    Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, long positionTicks, CancellationToken cancellationToken = default);
+    Task ReportPlaybackStoppedAsync(string itemId, string playSessionId, string deviceName, long positionTicks, CancellationToken cancellationToken = default);
 }

--- a/src/VirtualLib/Core/PlaybackEventForwarder.cs
+++ b/src/VirtualLib/Core/PlaybackEventForwarder.cs
@@ -98,7 +98,12 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
         var positionTicks = e.PlaybackPositionTicks ?? 0L;
         var isPaused      = e.IsPaused;
-        var sessionKey    = $"{connectorId}:{remoteItemId}";
+        // Normalize both sides to "N" (no-dash) GUID format for reliable comparison
+        var rawUserId   = e.Session?.UserId ?? "";
+        var localUserId = Guid.TryParse(rawUserId, out var sessionGuid) ? sessionGuid.ToString("N") : rawUserId;
+        var sessionKey  = $"{connectorId}:{remoteItemId}:{localUserId}";
+        var configUserId = Guid.TryParse(connectorConfig.LocalUserId ?? "", out var cfgGuid) ? cfgGuid.ToString("N") : (connectorConfig.LocalUserId ?? "");
+        var isLinkedUser = !string.IsNullOrEmpty(configUserId) && configUserId == localUserId;
 
         try
         {
@@ -113,7 +118,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
                     break;
 
                 case PlaybackEvent.Stop:
-                    HandleStop(connector, remoteItemId, sessionKey, positionTicks);
+                    HandleStop(connector, remoteItemId, sessionKey, positionTicks, isLinkedUser);
                     break;
             }
         }
@@ -173,16 +178,18 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private void HandleStop(
         IMediaServerConnector connector, string remoteItemId, string sessionKey,
-        long positionTicks)
+        long positionTicks, bool isLinkedUser)
     {
         if (!_sessions.TryGetValue(sessionKey, out var session)) return;
 
         // Annuler un Stop pending précédent
         session.PendingStopCts?.Cancel();
 
-        var stopCts         = new CancellationTokenSource();
-        var capturedId      = session.PlaySessionId;   // pour la vérification anti-race
-        var capturedPos     = positionTicks;
+        var stopCts     = new CancellationTokenSource();
+        var capturedId  = session.PlaySessionId;   // pour la vérification anti-race
+        // Seul le user lié au connecteur sauvegarde sa position sur le distant.
+        // Les autres users ferment la session proprement mais sans écraser le resume point distant.
+        var capturedPos = isLinkedUser ? positionTicks : 0L;
 
         _sessions[sessionKey] = session with { PendingStopCts = stopCts };
 
@@ -200,7 +207,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
                 {
                     s.HeartbeatCts.Cancel();
                     await connector.ReportPlaybackStoppedAsync(remoteItemId, s.PlaySessionId, capturedPos).ConfigureAwait(false);
-                    Console.Error.WriteLine($"[VirtualLib] Stop confirmé → item={remoteItemId} pos={capturedPos}");
+                    Console.Error.WriteLine($"[VirtualLib] Stop confirmé → item={remoteItemId} pos={capturedPos} linked={isLinkedUser}");
                 }
             }
             catch (OperationCanceledException)

--- a/src/VirtualLib/Core/PlaybackEventForwarder.cs
+++ b/src/VirtualLib/Core/PlaybackEventForwarder.cs
@@ -104,13 +104,15 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         var sessionKey  = $"{connectorId}:{remoteItemId}:{localUserId}";
         var configUserId = Guid.TryParse(connectorConfig.LocalUserId ?? "", out var cfgGuid) ? cfgGuid.ToString("N") : (connectorConfig.LocalUserId ?? "");
         var isLinkedUser = !string.IsNullOrEmpty(configUserId) && configUserId == localUserId;
+        // "cyril@Emby Web" — identifie le client local tel qu'il apparaît côté serveur distant
+        var deviceName = $"{e.Session?.UserName ?? localUserId}@{e.Session?.Client ?? "VirtualLib"}";
 
         try
         {
             switch (eventType)
             {
                 case PlaybackEvent.Start:
-                    await HandleStartAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused);
+                    await HandleStartAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused, deviceName);
                     break;
 
                 case PlaybackEvent.Progress:
@@ -134,7 +136,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private async Task HandleStartAsync(
         IMediaServerConnector connector, string remoteItemId, string sessionKey,
-        long positionTicks, bool isPaused)
+        long positionTicks, bool isPaused, string deviceName)
     {
         if (_sessions.TryRemove(sessionKey, out var prev))
         {
@@ -142,9 +144,9 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
             prev.HeartbeatCts.Cancel();
         }
 
-        var session = OpenSession(sessionKey, positionTicks, isPaused);
-        await connector.ReportPlaybackStartAsync(remoteItemId, session.PlaySessionId).ConfigureAwait(false);
-        Console.Error.WriteLine($"[VirtualLib] Start OK → item={remoteItemId} session={session.PlaySessionId}");
+        var session = OpenSession(sessionKey, positionTicks, isPaused, deviceName);
+        await connector.ReportPlaybackStartAsync(remoteItemId, session.PlaySessionId, session.DeviceName).ConfigureAwait(false);
+        Console.Error.WriteLine($"[VirtualLib] Start OK → item={remoteItemId} session={session.PlaySessionId} device={session.DeviceName}");
         _ = Task.Run(() => HeartbeatLoopAsync(connector, remoteItemId, sessionKey, session.HeartbeatCts.Token));
     }
 
@@ -157,10 +159,10 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         if (session is null)
         {
             // Session absente : debounce expiré, pod redémarré, ou host n'a pas renvoyé Start.
-            // Réouvrir transparentement.
+            // Réouvrir transparentement sans deviceName connu — fallback vide.
             Console.Error.WriteLine($"[VirtualLib] Progress sans session active — réouverture pour item={remoteItemId}");
-            session = OpenSession(sessionKey, positionTicks, isPaused);
-            await connector.ReportPlaybackStartAsync(remoteItemId, session.PlaySessionId).ConfigureAwait(false);
+            session = OpenSession(sessionKey, positionTicks, isPaused, "VirtualLib");
+            await connector.ReportPlaybackStartAsync(remoteItemId, session.PlaySessionId, session.DeviceName).ConfigureAwait(false);
             _ = Task.Run(() => HeartbeatLoopAsync(connector, remoteItemId, sessionKey, session.HeartbeatCts.Token));
         }
         else if (session.PendingStopCts != null)
@@ -173,7 +175,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         }
 
         _sessions[sessionKey] = session with { PositionTicks = positionTicks, IsPaused = isPaused };
-        await connector.ReportPlaybackProgressAsync(remoteItemId, session.PlaySessionId, positionTicks, isPaused).ConfigureAwait(false);
+        await connector.ReportPlaybackProgressAsync(remoteItemId, session.PlaySessionId, session.DeviceName, positionTicks, isPaused).ConfigureAwait(false);
     }
 
     private void HandleStop(
@@ -185,11 +187,12 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         // Annuler un Stop pending précédent
         session.PendingStopCts?.Cancel();
 
-        var stopCts     = new CancellationTokenSource();
-        var capturedId  = session.PlaySessionId;   // pour la vérification anti-race
+        var stopCts        = new CancellationTokenSource();
+        var capturedId     = session.PlaySessionId;   // pour la vérification anti-race
+        var capturedDevice = session.DeviceName;
         // Seul le user lié au connecteur sauvegarde sa position sur le distant.
         // Les autres users ferment la session proprement mais sans écraser le resume point distant.
-        var capturedPos = isLinkedUser ? positionTicks : 0L;
+        var capturedPos    = isLinkedUser ? positionTicks : 0L;
 
         _sessions[sessionKey] = session with { PendingStopCts = stopCts };
 
@@ -206,7 +209,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
                     && _sessions.TryRemove(sessionKey, out var s))
                 {
                     s.HeartbeatCts.Cancel();
-                    await connector.ReportPlaybackStoppedAsync(remoteItemId, s.PlaySessionId, capturedPos).ConfigureAwait(false);
+                    await connector.ReportPlaybackStoppedAsync(remoteItemId, s.PlaySessionId, capturedDevice, capturedPos).ConfigureAwait(false);
                     Console.Error.WriteLine($"[VirtualLib] Stop confirmé → item={remoteItemId} pos={capturedPos} linked={isLinkedUser}");
                 }
             }
@@ -236,7 +239,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
                 if (ct.IsCancellationRequested || !_sessions.TryGetValue(sessionKey, out var session)) break;
 
                 await connector.ReportPlaybackProgressAsync(
-                    remoteItemId, session.PlaySessionId, session.PositionTicks, session.IsPaused, ct)
+                    remoteItemId, session.PlaySessionId, session.DeviceName, session.PositionTicks, session.IsPaused, ct)
                     .ConfigureAwait(false);
 
                 Console.Error.WriteLine($"[VirtualLib] Heartbeat → item={remoteItemId} pos={session.PositionTicks} paused={session.IsPaused}");
@@ -250,9 +253,9 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
     // Helpers
     // -------------------------------------------------------------------------
 
-    private ActiveSession OpenSession(string sessionKey, long positionTicks, bool isPaused)
+    private ActiveSession OpenSession(string sessionKey, long positionTicks, bool isPaused, string deviceName)
     {
-        var session = new ActiveSession(Guid.NewGuid().ToString("N"), positionTicks, isPaused, new CancellationTokenSource());
+        var session = new ActiveSession(Guid.NewGuid().ToString("N"), deviceName, positionTicks, isPaused, new CancellationTokenSource());
         _sessions[sessionKey] = session;
         return session;
     }
@@ -284,6 +287,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private sealed record ActiveSession(
         string PlaySessionId,
+        string DeviceName,
         long PositionTicks,
         bool IsPaused,
         CancellationTokenSource HeartbeatCts,

--- a/src/VirtualLib/Core/PlaybackEventForwarder.cs
+++ b/src/VirtualLib/Core/PlaybackEventForwarder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Session;
@@ -35,14 +36,21 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
     private readonly ISessionManager _sessionManager;
     private readonly ILogger<PlaybackEventForwarder> _logger;
     private readonly IConnectorFactory _connectorFactory;
+    private readonly IUserDataManager? _userDataManager;
+    private readonly IUserManager? _userManager;
 
     private readonly ConcurrentDictionary<string, IMediaServerConnector> _connectors = new();
     private readonly ConcurrentDictionary<string, ActiveSession> _sessions = new();
 
-    public PlaybackEventForwarder(ISessionManager sessionManager)
+    public PlaybackEventForwarder(
+        ISessionManager sessionManager,
+        IUserDataManager userDataManager,
+        IUserManager userManager)
     {
-        _sessionManager = sessionManager;
-        _logger = NullLoggerFactory.Instance.CreateLogger<PlaybackEventForwarder>();
+        _sessionManager   = sessionManager;
+        _userDataManager  = userDataManager;
+        _userManager      = userManager;
+        _logger           = NullLoggerFactory.Instance.CreateLogger<PlaybackEventForwarder>();
         _connectorFactory = new ConnectorFactory(new DefaultHttpClientFactory(), NullLoggerFactory.Instance);
     }
 
@@ -112,15 +120,15 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
             switch (eventType)
             {
                 case PlaybackEvent.Start:
-                    await HandleStartAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused, deviceName);
+                    await HandleStartAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused, deviceName, isLinkedUser);
                     break;
 
                 case PlaybackEvent.Progress:
-                    await HandleProgressAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused);
+                    await HandleProgressAsync(connector, remoteItemId, sessionKey, positionTicks, isPaused, isLinkedUser);
                     break;
 
                 case PlaybackEvent.Stop:
-                    HandleStop(connector, remoteItemId, sessionKey, positionTicks, isLinkedUser);
+                    HandleStop(connector, remoteItemId, sessionKey, connectorId, configUserId, e.Item, positionTicks, isLinkedUser);
                     break;
             }
         }
@@ -136,7 +144,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private async Task HandleStartAsync(
         IMediaServerConnector connector, string remoteItemId, string sessionKey,
-        long positionTicks, bool isPaused, string deviceName)
+        long positionTicks, bool isPaused, string deviceName, bool isLinkedUser)
     {
         if (_sessions.TryRemove(sessionKey, out var prev))
         {
@@ -144,7 +152,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
             prev.HeartbeatCts.Cancel();
         }
 
-        var session = OpenSession(sessionKey, positionTicks, isPaused, deviceName);
+        var session = OpenSession(sessionKey, positionTicks, isPaused, deviceName, isLinkedUser);
         await connector.ReportPlaybackStartAsync(remoteItemId, session.PlaySessionId, session.DeviceName).ConfigureAwait(false);
         Console.Error.WriteLine($"[VirtualLib] Start OK → item={remoteItemId} session={session.PlaySessionId} device={session.DeviceName}");
         _ = Task.Run(() => HeartbeatLoopAsync(connector, remoteItemId, sessionKey, session.HeartbeatCts.Token));
@@ -152,8 +160,22 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private async Task HandleProgressAsync(
         IMediaServerConnector connector, string remoteItemId, string sessionKey,
-        long positionTicks, bool isPaused)
+        long positionTicks, bool isPaused, bool isLinkedUser)
     {
+        // L'API Emby (Sessions/Playing/Progress) met à jour le "Now Playing" ET la position
+        // de reprise (UserData) en même temps. Si plusieurs users regardent le même item,
+        // leurs Progress s'écrasent mutuellement → position oscillante.
+        // Solution : seul le user lié envoie ses Progress vers le distant.
+        // Les autres users n'envoient que Start et Stop (position=0) — leur session
+        // distante expirera naturellement après le timeout d'inactivité du serveur.
+        if (!isLinkedUser)
+        {
+            // Mettre à jour la position locale pour que le Stop capture la bonne valeur
+            if (_sessions.TryGetValue(sessionKey, out var s))
+                _sessions[sessionKey] = s with { PositionTicks = positionTicks, IsPaused = isPaused };
+            return;
+        }
+
         _sessions.TryGetValue(sessionKey, out var session);
 
         if (session is null)
@@ -180,6 +202,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
 
     private void HandleStop(
         IMediaServerConnector connector, string remoteItemId, string sessionKey,
+        string connectorId, string configUserId, BaseItem? item,
         long positionTicks, bool isLinkedUser)
     {
         if (!_sessions.TryGetValue(sessionKey, out var session)) return;
@@ -190,9 +213,11 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         var stopCts        = new CancellationTokenSource();
         var capturedId     = session.PlaySessionId;   // pour la vérification anti-race
         var capturedDevice = session.DeviceName;
-        // Seul le user lié au connecteur sauvegarde sa position sur le distant.
-        // Les autres users ferment la session proprement mais sans écraser le resume point distant.
-        var capturedPos    = isLinkedUser ? positionTicks : 0L;
+        // User lié : envoyer sa position réelle.
+        // User non-lié (B) : restaurer la position du user lié (A) pour ne pas écraser son resume point.
+        var capturedPos    = isLinkedUser
+            ? positionTicks
+            : ResolveLinkedUserPosition(connectorId, remoteItemId, configUserId, item);
 
         _sessions[sessionKey] = session with { PendingStopCts = stopCts };
 
@@ -253,9 +278,44 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
     // Helpers
     // -------------------------------------------------------------------------
 
-    private ActiveSession OpenSession(string sessionKey, long positionTicks, bool isPaused, string deviceName)
+    /// <summary>
+    /// Résout la position à envoyer au Stop d'un user non-lié (B) :
+    /// 1. Session active de A → position en cours.
+    /// 2. UserData local de A → dernière position sauvegardée.
+    /// 3. Fallback → 0 (pas de connecteur configuré ou user introuvable).
+    /// </summary>
+    private long ResolveLinkedUserPosition(string connectorId, string remoteItemId, string configUserId, BaseItem? item)
     {
-        var session = new ActiveSession(Guid.NewGuid().ToString("N"), deviceName, positionTicks, isPaused, new CancellationTokenSource());
+        if (string.IsNullOrEmpty(configUserId)) return 0L;
+
+        // 1. A est en train de regarder — utiliser sa position de session active
+        var linkedSessionKey = $"{connectorId}:{remoteItemId}:{configUserId}";
+        if (_sessions.TryGetValue(linkedSessionKey, out var linkedSession))
+        {
+            Console.Error.WriteLine($"[VirtualLib] Stop(B) restaure pos A (session active): {linkedSession.PositionTicks}");
+            return linkedSession.PositionTicks;
+        }
+
+        // 2. A ne regarde pas — lire sa position depuis le UserData local
+        if (_userDataManager is not null && _userManager is not null && item is not null)
+        {
+            var user = _userManager.Users.FirstOrDefault(u =>
+                string.Equals(u.Id.ToString("N"), configUserId, StringComparison.OrdinalIgnoreCase));
+            if (user is not null)
+            {
+                var pos = _userDataManager.GetUserData(user, item).PlaybackPositionTicks;
+                Console.Error.WriteLine($"[VirtualLib] Stop(B) restaure pos A (UserData local): {pos}");
+                return pos;
+            }
+        }
+
+        Console.Error.WriteLine($"[VirtualLib] Stop(B) user lié introuvable, envoi pos=0");
+        return 0L;
+    }
+
+    private ActiveSession OpenSession(string sessionKey, long positionTicks, bool isPaused, string deviceName, bool isLinkedUser = false)
+    {
+        var session = new ActiveSession(Guid.NewGuid().ToString("N"), deviceName, positionTicks, isPaused, isLinkedUser, new CancellationTokenSource());
         _sessions[sessionKey] = session;
         return session;
     }
@@ -290,6 +350,7 @@ public sealed class PlaybackEventForwarder : IServerEntryPoint
         string DeviceName,
         long PositionTicks,
         bool IsPaused,
+        bool IsLinkedUser,
         CancellationTokenSource HeartbeatCts,
         CancellationTokenSource? PendingStopCts = null);
 }

--- a/src/VirtualLib/Core/SyncService.cs
+++ b/src/VirtualLib/Core/SyncService.cs
@@ -530,7 +530,7 @@ public sealed class SyncService
                             }
 
                             // Sync favorite/played state for the show folder itself
-                            SyncUserFlagsForFolder(showFolder, showMeta, ct);
+                            SyncUserFlagsForFolder(showFolder, showMeta, ct, config.LocalUserId);
                         }
                         catch (OperationCanceledException) { throw; }
                         catch (Exception ex)
@@ -561,7 +561,7 @@ public sealed class SyncService
                         }
 
                         // Sync favorite/played state for the season folder itself
-                        SyncUserFlagsForFolder(nfoDir, seasonMeta, ct);
+                        SyncUserFlagsForFolder(nfoDir, seasonMeta, ct, config.LocalUserId);
                     }
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex)
@@ -692,7 +692,8 @@ public sealed class SyncService
         List<(string StrmPath, MediaItem Item)> pending,
         string libraryName,
         IProgress<SyncProgress>? progress,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? localUserId = null)
     {
         if (_libraryManager is null || pending.Count == 0) return;
 
@@ -783,7 +784,7 @@ public sealed class SyncService
                             "VirtualLib: SaveMediaStreams SKIPPED for '{Title}' — _itemRepository={R} Technical={T}",
                             item.Title, _itemRepository is not null, item.Technical is not null);
 
-                    // Sync played/favorite/resume-position for all local users
+                    // Sync played/favorite/resume-position for the linked local user only
                     _logger.LogDebug(
                         "VirtualLib: user flags from source — '{Title}': played={P} count={PC} pos={Pos} fav={F}",
                         item.Title, item.IsPlayed, item.PlayCount, item.PlaybackPositionTicks, item.IsFavorite);
@@ -791,7 +792,7 @@ public sealed class SyncService
                     if (_userDataManager is not null && _userManager is not null
                         && (item.IsPlayed || item.IsFavorite || item.PlayCount > 0 || item.PlaybackPositionTicks > 0))
                     {
-                        SyncUserFlags(baseItem, item, ct);
+                        SyncUserFlags(baseItem, item, ct, localUserId);
                     }
 
                     // Patch NFO with <fileinfo><streamdetails> as additional persistence.
@@ -888,7 +889,7 @@ public sealed class SyncService
     /// Finds a folder item by path in the local library and syncs its user flags.
     /// No-op if the folder isn't in Emby yet (first sync) or if all flags are unset.
     /// </summary>
-    private void SyncUserFlagsForFolder(string folderPath, MediaItem item, CancellationToken ct)
+    private void SyncUserFlagsForFolder(string folderPath, MediaItem item, CancellationToken ct, string? localUserId = null)
     {
         if (_libraryManager is null || _userDataManager is null || _userManager is null) return;
         if (!item.IsPlayed && !item.IsFavorite && item.PlayCount == 0 && item.PlaybackPositionTicks == 0) return;
@@ -897,7 +898,7 @@ public sealed class SyncService
         {
             var folder = _libraryManager.FindByPath(folderPath, true);
             if (folder is null) return; // not yet scanned — will be picked up on next sync
-            SyncUserFlags(folder, item, ct);
+            SyncUserFlags(folder, item, ct, localUserId);
         }
         catch (Exception ex)
         {
@@ -906,22 +907,38 @@ public sealed class SyncService
     }
 
     /// <summary>
-    /// Copies played/favorite state from the remote item to all local Emby users.
+    /// Copies played/favourite state from the remote item to the linked local Emby user.
+    /// When <paramref name="localUserId"/> is null or empty, the sync is skipped entirely.
     /// Only called when at least one flag is set on the remote side.
     /// </summary>
-    private void SyncUserFlags(BaseItem baseItem, MediaItem item, CancellationToken ct)
+    private void SyncUserFlags(BaseItem baseItem, MediaItem item, CancellationToken ct, string? localUserId = null)
     {
+        if (string.IsNullOrEmpty(localUserId))
+        {
+            _logger.LogDebug(
+                "VirtualLib: SyncUserFlags skipped for '{Title}' — no LocalUserId configured on connector",
+                item.Title);
+            return;
+        }
+
         _logger.LogInformation(
-            "VirtualLib: SyncUserFlags '{Title}' — played={P} playCount={PC} positionTicks={Pos} favorite={F}",
-            item.Title, item.IsPlayed, item.PlayCount, item.PlaybackPositionTicks, item.IsFavorite);
+            "VirtualLib: SyncUserFlags '{Title}' — played={P} playCount={PC} positionTicks={Pos} favorite={F} → localUser={U}",
+            item.Title, item.IsPlayed, item.PlayCount, item.PlaybackPositionTicks, item.IsFavorite, localUserId);
 
         try
         {
 #pragma warning disable CS0618 // IUserManager.Users is deprecated but the replacement (GetUsers) requires a UserQuery filter
-            foreach (var user in _userManager!.Users)
+            var normalizedTarget = Guid.TryParse(localUserId, out var tg) ? tg.ToString("N") : localUserId;
+            var user = _userManager!.Users.FirstOrDefault(u =>
+                string.Equals(u.Id.ToString("N"), normalizedTarget, StringComparison.OrdinalIgnoreCase));
 #pragma warning restore CS0618
+            if (user is null)
             {
-                var userData = _userDataManager!.GetUserData(user, baseItem);
+                _logger.LogWarning("VirtualLib: SyncUserFlags — local user '{UserId}' not found, skipping", localUserId);
+                return;
+            }
+
+            var userData = _userDataManager!.GetUserData(user, baseItem);
 
                 // Only update if the remote state differs (avoid unnecessary writes)
                 bool changed = false;
@@ -955,7 +972,6 @@ public sealed class SyncService
 
                 if (changed)
                     _userDataManager.SaveUserData(user, baseItem, userData, EmbyUserDataSaveReason.Import, ct);
-            }
         }
         catch (Exception ex)
         {

--- a/src/VirtualLib/PluginConfiguration.cs
+++ b/src/VirtualLib/PluginConfiguration.cs
@@ -90,6 +90,15 @@ public sealed class ConnectorConfig
     public int MaxParallelLibraries { get; set; } = 4;
 
     /// <summary>
+    /// ID of the local Emby user whose personal data (played, favourite, resume position)
+    /// is synchronised with this connector.
+    /// Playback sessions are forwarded to the remote server for ALL local users,
+    /// but only this user's stop position is persisted on the remote side.
+    /// Leave empty to disable personal-data sync entirely.
+    /// </summary>
+    public string LocalUserId { get; set; } = string.Empty;
+
+    /// <summary>
     /// Controls how the Emby virtual library is named and shared.
     /// Physical files are always at Root/ConnectorName/LibraryName/ in both modes.
     /// Isolated (default): one dedicated Emby library per remote library, named "ConnectorName — LibraryName".

--- a/src/VirtualLib/VirtualLib.csproj
+++ b/src/VirtualLib/VirtualLib.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>VirtualLib</AssemblyName>
     <RootNamespace>VirtualLib</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.8.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/VirtualLib/Web_Pages/config.html
+++ b/src/VirtualLib/Web_Pages/config.html
@@ -251,6 +251,18 @@
                 </div>
 
                 <div class="inputContainer" style="margin-top:1em">
+                    <label class="inputLabel inputLabelUnfocused" for="connectorLocalUserId">Linked Local User</label>
+                    <select id="connectorLocalUserId" is="emby-select" class="emby-select-withcolor emby-input">
+                        <option value="">— None (personal data sync disabled) —</option>
+                    </select>
+                    <div class="fieldDescription">
+                        Local Emby user whose personal data (played, favourite, resume position) is synchronised
+                        with this connector. Playback sessions are forwarded for <strong>all</strong> local users,
+                        but only this user's stop position is saved on the remote server.
+                    </div>
+                </div>
+
+                <div class="inputContainer" style="margin-top:1em">
                     <label class="inputLabel inputLabelUnfocused" for="connectorMaxParallel">Max Parallel Libraries</label>
                     <input type="number" id="connectorMaxParallel" class="emby-input" min="1" max="16" value="4" />
                     <div class="fieldDescription">

--- a/src/VirtualLib/Web_Pages/configjs.js
+++ b/src/VirtualLib/Web_Pages/configjs.js
@@ -381,6 +381,24 @@ define([], function () {
             sel.appendChild(opt);
         }
 
+        function loadLocalUsers(selectedId) {
+            ApiClient.getUsers().then(function (users) {
+                var sel = q('connectorLocalUserId');
+                while (sel.firstChild) sel.removeChild(sel.firstChild);
+                var none = document.createElement('option');
+                none.value = '';
+                none.textContent = '\u2014 None (personal data sync disabled) \u2014';
+                sel.appendChild(none);
+                users.forEach(function (u) {
+                    var opt = document.createElement('option');
+                    opt.value = u.Id;
+                    opt.textContent = u.Name;
+                    sel.appendChild(opt);
+                });
+                sel.value = selectedId || '';
+            }).catch(function () { /* best-effort — leave placeholder */ });
+        }
+
         function openAddConnector() {
             q('connectorId').value = '';
             q('connectorName').value = '';
@@ -393,6 +411,7 @@ define([], function () {
             q('connectorMetadataMode').value = 'RemoteSync';
             q('connectorMaxParallel').value = 4;
             q('connectorLibraryOrganization').value = 'Isolated';
+            loadLocalUsers('');
             q('plexTwoFactorPin').value = '';
             resetPlexServerPicker();
             clearStatus(q('plexServersStatus'));
@@ -429,6 +448,7 @@ define([], function () {
                 q('connectorMetadataMode').value = c.MetadataMode || 'RemoteSync';
                 q('connectorMaxParallel').value = c.MaxParallelLibraries || 4;
                 q('connectorLibraryOrganization').value = c.LibraryOrganization || 'Isolated';
+                loadLocalUsers(c.LocalUserId || '');
 
                 // Restore PlexTV machine picker with saved identifier
                 var sel = q('plexMachineId');
@@ -949,6 +969,7 @@ define([], function () {
                 var metadataMode          = q('connectorMetadataMode').value;
                 var maxParallel           = parseInt(q('connectorMaxParallel').value, 10) || 4;
                 var libraryOrganization   = q('connectorLibraryOrganization').value;
+                var localUserId           = q('connectorLocalUserId').value;
 
                 if (!displayName) {
                     setStatus(statusEl, 'Name is required.', true);
@@ -988,6 +1009,7 @@ define([], function () {
                             MetadataMode: metadataMode,
                             MaxParallelLibraries: maxParallel,
                             LibraryOrganization: libraryOrganization,
+                            LocalUserId: localUserId,
                             LibraryIds: existing ? (existing.LibraryIds || []) : [],
                             Enabled: true
                         };
@@ -1014,6 +1036,7 @@ define([], function () {
                         MetadataMode: metadataMode,
                         MaxParallelLibraries: maxParallel,
                         LibraryOrganization: libraryOrganization,
+                        LocalUserId: localUserId,
                         LibraryIds: [],
                         Enabled: true
                     };


### PR DESCRIPTION
## Summary

- Each local user gets their own independent playback session on the remote server, keyed by `connectorId:itemId:userId`
- Only the linked user (A) forwards `Progress` events — other users (B) only send `Start`/`Stop`, avoiding UserData oscillation
- Device identity uses `user@client` format (e.g. `cyril@Emby Web`) so each stream appears correctly on the remote dashboard
- `playSessionId` used as `DeviceId` in `X-Emby-Authorization` so concurrent streams appear as distinct sessions on the remote
- At B's `Stop`, the linked user A's position is restored (from active session or local `IUserDataManager`) to prevent overwriting A's resume point
- `SyncUserFlags` now targets only the linked user instead of all local users
- UI: "Linked Local User" dropdown added to the connector form

## Test plan

- [ ] Two users watching the same item: remote shows 2 sessions, each with correct device name
- [ ] B stops: remote resume point is A's position, not B's (or 0)
- [ ] A stops while B is still watching: A's Stop sends correct position, B's heartbeat continues
- [ ] Played/Favorite flags sync only for the linked user
- [ ] Single user (no linked user configured): behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)